### PR TITLE
Fieldname casing option on conversion from generic IndexDefinition to Azure

### DIFF
--- a/src/Nethereum.BlockchainStore.Search.Azure/AzureSearchExtensions.cs
+++ b/src/Nethereum.BlockchainStore.Search.Azure/AzureSearchExtensions.cs
@@ -48,7 +48,7 @@ namespace Nethereum.BlockchainStore.Search.Azure
             var dictionary = new GenericSearchDocument();
             foreach (var field in searchFields)
             {
-                var azureField = field.ToAzureField();
+                var azureField = field.ToAzureField(convertNameToLowercase: true);
 
                 var val = getValue.Invoke(field)?.ToAzureFieldValue();
                 if (val != null)
@@ -60,12 +60,12 @@ namespace Nethereum.BlockchainStore.Search.Azure
             return dictionary;
         }
 
-        public static Index ToAzureIndex(this IndexDefinition searchIndex)
+        public static Index ToAzureIndex(this IndexDefinition searchIndex, bool convertFieldNamesToLowercase = false)
         {
             var index = new Index
             {
                 Name = searchIndex.IndexName.ToAzureIndexName(), 
-                Fields = searchIndex.Fields.ToAzureFields(), 
+                Fields = searchIndex.Fields.ToAzureFields(convertFieldNamesToLowercase), 
                 Suggesters = searchIndex.Fields.ToAzureSuggesters()
             };
 
@@ -88,14 +88,14 @@ namespace Nethereum.BlockchainStore.Search.Azure
             return new[] {new Suggester(SuggesterName, suggesterFields.Select(f => f.Name.ToLower()).ToArray())};
         }
 
-        public static Field[] ToAzureFields(this IEnumerable<SearchField> fields)
+        public static Field[] ToAzureFields(this IEnumerable<SearchField> fields, bool convertNameToLowercase = false)
         {
-            return fields.Select(ToAzureField).ToArray();
+            return fields.Select(f => f.ToAzureField(convertNameToLowercase)).ToArray();
         }
 
-        public static Field ToAzureField(this SearchField f)
+        public static Field ToAzureField(this SearchField f, bool convertNameToLowercase = false)
         {
-            return new Field(f.Name.ToAzureFieldName(), f.IsCollection ? DataType.Collection(f.DataType.ToAzureDataType()) : f.DataType.ToAzureDataType())
+            return new Field(f.Name.ToAzureFieldName(convertNameToLowercase), f.IsCollection ? DataType.Collection(f.DataType.ToAzureDataType()) : f.DataType.ToAzureDataType())
             {
                 IsKey = f.IsKey,
                 IsFilterable = f.IsFilterable,
@@ -105,9 +105,9 @@ namespace Nethereum.BlockchainStore.Search.Azure
             };
         }
 
-        public static string ToAzureFieldName(this string fieldName)
+        public static string ToAzureFieldName(this string fieldName, bool convertNameToLowercase = false)
         {
-            return fieldName.ToLower().Replace(".", "_");
+            return (convertNameToLowercase ? fieldName.ToLower() : fieldName).Replace(".", "_");
         }
 
         public static object ToAzureFieldValue(this object val)

--- a/src/Nethereum.BlockchainStore.Search.Azure/AzureSearchService.cs
+++ b/src/Nethereum.BlockchainStore.Search.Azure/AzureSearchService.cs
@@ -61,19 +61,19 @@ namespace Nethereum.BlockchainStore.Search.Azure
             return index;
         }
 
-        public Task<Index> CreateIndexAsync(IndexDefinition indexDefinition)
-            => CreateIndexAsync(indexDefinition.ToAzureIndex());
+        public Task<Index> CreateIndexAsync(IndexDefinition indexDefinition, bool convertFieldNamesToLowerCase = false)
+            => CreateIndexAsync(indexDefinition.ToAzureIndex(convertFieldNamesToLowerCase));
 
         public Task<Index> CreateIndexForLogAsync(string indexName)
             => CreateIndexAsync(FilterLogIndexUtil.Create(indexName));
 
         public Task<Index> CreateIndexForEventLogAsync<TEventDTO>(string indexName = null)
             where TEventDTO : class
-            => CreateIndexAsync(new EventIndexDefinition<TEventDTO>(indexName));
+            => CreateIndexAsync(new EventIndexDefinition<TEventDTO>(indexName), convertFieldNamesToLowerCase: true);
 
         public Task<Index> CreateIndexForFunctionMessageAsync<TFunctionMessage>(string indexName = null)
             where TFunctionMessage : FunctionMessage
-            => CreateIndexAsync(new FunctionIndexDefinition<TFunctionMessage>(indexName));
+            => CreateIndexAsync(new FunctionIndexDefinition<TFunctionMessage>(indexName), convertFieldNamesToLowerCase: true);
 
         public async Task<Index> GetIndexAsync(string indexName)
         {

--- a/src/Nethereum.BlockchainStore.Search.Azure/IAzureSearchService.cs
+++ b/src/Nethereum.BlockchainStore.Search.Azure/IAzureSearchService.cs
@@ -10,7 +10,7 @@ namespace Nethereum.BlockchainStore.Search.Azure
     {
         Task<Index> GetIndexAsync(string indexName);
         Task<Index> CreateIndexAsync(Index index);
-        Task<Index> CreateIndexAsync(IndexDefinition indexDefinition);
+        Task<Index> CreateIndexAsync(IndexDefinition indexDefinition, bool convertFieldNamesToLowerCase = false);
         Task<Index> CreateIndexForEventLogAsync<TEventDTO>(string indexName = null) where TEventDTO : class;
         Task<Index> CreateIndexForLogAsync(string indexName);
         Task<Index> CreateIndexForFunctionMessageAsync<TFunctionMessage>(string indexName = null)

--- a/src/Nethereum.BlockchainStore.Search.Tests/Azure/AzureEventSearchExtensionTests.cs
+++ b/src/Nethereum.BlockchainStore.Search.Tests/Azure/AzureEventSearchExtensionTests.cs
@@ -54,7 +54,7 @@ namespace Nethereum.BlockchainStore.Search.Tests.Azure
                 IsSuggester = true
             };
 
-            var azureField = eventSearchField.ToAzureField();
+            var azureField = eventSearchField.ToAzureField(convertNameToLowercase: true);
             Assert.Equal("fielda_val", azureField.Name);
             Assert.Equal(DataType.String, azureField.Type);
             Assert.True(azureField.IsFacetable);
@@ -62,6 +62,14 @@ namespace Nethereum.BlockchainStore.Search.Tests.Azure
             Assert.True(azureField.IsFilterable);
             Assert.True(azureField.IsSortable);
             Assert.True(azureField.IsSearchable);
+        }
+
+        [Fact]
+        public void ToAzureFieldName()
+        {
+            Assert.Equal("FieldA", "FieldA".ToAzureFieldName());
+            Assert.Equal("FieldA", "FieldA".ToAzureFieldName(convertNameToLowercase: false));
+            Assert.Equal("fielda", "FieldA".ToAzureFieldName(convertNameToLowercase: true));
         }
 
         [Fact]
@@ -86,7 +94,7 @@ namespace Nethereum.BlockchainStore.Search.Tests.Azure
                 new SearchField("FieldB")
             };
 
-            var azureSearchFields = fields.ToAzureFields();
+            var azureSearchFields = fields.ToAzureFields(convertNameToLowercase: true);
             Assert.Equal(2, azureSearchFields.Length);
             Assert.Equal("fielda_prop1", azureSearchFields[0].Name);
             Assert.Equal("fieldb", azureSearchFields[1].Name);
@@ -128,6 +136,10 @@ namespace Nethereum.BlockchainStore.Search.Tests.Azure
 
             Assert.Equal("indexa", azureIndex.Name);
             Assert.Equal(eventSearchDefinition.Fields.Length, azureIndex.Fields.Count);
+            Assert.Equal("FieldA", azureIndex.Fields[0].Name);
+
+            azureIndex = eventSearchDefinition.ToAzureIndex(convertFieldNamesToLowercase: true);
+            Assert.Equal("fielda", azureIndex.Fields[0].Name);
         }
 
         [Event("Transfer")]


### PR DESCRIPTION
The previous pattern was automatically convert field names to lower case when creating an Azure index from a generic IndexDefinition.

This worked for auto generated index definitions based on Nethereum Event/Function DTO's.  These use a dictionary to carry the search document data rather than a DTO.   A typical approach was to go from EventDTO -> IndexDefinition -> Azure Index.   Under the hood this creates an index with lower case fields and populates a search document dictionary with lower cased fields.  

However when using specific search documents (POCO's/DTO's) it can cause inconsistent casing between the fields in the Azure index and the fields serialized in search documents.   This can mean that new documents can not be added to the index.

I have added an optional parameter with a default value to set the casing.  Therefore it's not a breaking change.